### PR TITLE
use inflection.camelize instead str.istitle

### DIFF
--- a/qstylizer/style.py
+++ b/qstylizer/style.py
@@ -110,7 +110,7 @@ class StyleRule(
 
         """
         key = str(key)
-        if key and key[0] not in ["Q", "#", "[", " "] and not key.istitle():
+        if key and key[0] not in ["Q", "#", "[", " "] and key != inflection.camelize(key):
             key = inflection.underscore(key)
         return (
             key


### PR DESCRIPTION
According to [PEP 8](https://www.python.org/dev/peps/pep-0008/#class-names) the classes must be CapWords so the CustomTabBar class name is valid, but if a qss is parsed with that class it is converted to "custom-tab-bar" which is incorrect. This PR tries to solve it.