### PR TITLE
Fix two setuptools warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,9 @@
 name = qstylizer
 author = Brett Lambright
 summary = Stylesheet Generator for PyQt{4-5}/PySide{1-2}
-description-file = README.rst
+description_file = README.rst
 license = MIT
-home-page = https://github.com/blambright/qstylizer
+home_page = https://github.com/blambright/qstylizer
 classifier =
     Development Status :: 4 - Beta
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
UserWarning: Usage of dash-separated 'home-page' will not be supported in future versions. Please use the underscore name 'home_page' instead