### PR TITLE
Fix typo in tests: use assert_called_once_with()

### DIFF
--- a/test/unit/test_style.py
+++ b/test/unit/test_style.py
@@ -184,7 +184,7 @@ def test_create_child_rule_list(mocker, style_class, css):
     )
     mocked_set_child_rule = mocker.patch.object(style_class, "set_child_rule")
     assert css.create_child_rule_list(name) == style_list
-    mocked_set_child_rule.called_once_with(name, style_list)
+    mocked_set_child_rule.assert_called_once_with(name, style_list)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix a typo in tests whereas `.called_once_with()` is called rather than `.assert_called_once_with()`.  This gets mocked in Python < 3.12 and therefore it is ignored (but doesn't test correctly) but it triggers an error in Python 3.12:

```
E               AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?
```