### PR TITLE
Fix regex string to stop SyntaxWarning

### DIFF
--- a/qstylizer/style.py
+++ b/qstylizer/style.py
@@ -65,7 +65,7 @@ class StyleRule(
         }
 
     """
-    _split_regex = '\*|\[[A-Za-z0-9=\'"_:]+\]|\W*\w*'
+    _split_regex = r"""\*|\[[A-Za-z0-9='"_:]+\]|\W*\w*"""
 
     @classmethod
     def split_selector(cls, selector):


### PR DESCRIPTION
The changed `_split_regex` is now a syntactically invalid string; running Python 3.12 gives a `SyntaxWarning`:

```
euler $ python3.12
Python 3.12.7 (main, Nov  8 2024, 17:55:36) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> _split_regex = '\*|\[[A-Za-z0-9=\'"_:]+\]|\W*\w*'
<stdin>:1: SyntaxWarning: invalid escape sequence '\*'
>>> 
```

This patch fixes the problem by using triple quotes and a raw string; within triple quotes, a single quote does not signify the end of the string.